### PR TITLE
Fixed potentially confusing readme typo in the instructions for composer...

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-If you are using composer, just add `hull/hull-sdk`  this to your `composer.json` file :
+If you are using composer, just add `hull/hull` to your `composer.json` file :
 
     {
       "name" : "my-org/my-awesome-hull-project",


### PR DESCRIPTION
Instructions must not have been completely updated at some point. Made more confusing by the fact that "hull-sdk" is present on [packagist](https://packagist.org/packages/hull/hull-sdk). (obviously the issue here is that if one tries to install "hull-sdk" it doesn't work due to the repository not existing)
