### PR TITLE
Replaced preg_replace() with preg_replace_callback() in Hull/Connection.php

### DIFF
--- a/Hull/Connection.php
+++ b/Hull/Connection.php
@@ -6,7 +6,12 @@
       $fields = explode("\r\n", preg_replace('/\x0D\x0A[\x09\x20]+/', ' ', $header));
       foreach( $fields as $field ) {
         if( preg_match('/([^:]+): (.+)/m', $field, $match) ) {
-          $match[1] = preg_replace('/(?<=^|[\x09\x20\x2D])./e', 'strtoupper("\0")', strtolower(trim($match[1])));
+          $match[1] = preg_replace_callback('/(?<=^|[\x09\x20\x2D])./',
+            function($matches){
+              return strtoupper($matches[0]);
+            },
+            strtolower(trim($match[1])));
+          
           if( isset($retVal[$match[1]]) ) {
             $retVal[$match[1]] = array($retVal[$match[1]], $match[2]);
           } else {


### PR DESCRIPTION
This due to [preg_replace()](http://www.php.net/manual/en/function.preg-replace.php) with the /e option being [deprecated](http://php.net/manual/en/migration55.deprecated.php) in php 5.5.0 & now throwing an exception.
The fix is replacing with [preg_replace_callback()](http://www.php.net/manual/en/function.preg-replace-callback.php)

**Note**
- Change creates compatibility with php 5.5.x
- Change breaks compatibility with php 4 < 4.0.5
