### PR TITLE
Make `_http_exec` method pass response headers

### DIFF
--- a/Hull/Connection.php
+++ b/Hull/Connection.php
@@ -174,7 +174,7 @@
         $body = array();
       }
 
-      $res = array("status" => $status, "body" => $body);
+      $res = array("status" => $status, "body" => $body, "headers" => $response_headers);
 
       if ($status >= 400) {
         throw new Exception(json_encode($res));


### PR DESCRIPTION
When doing api call with "raw" option one will get additional "headers" array which makes working with pagination data possible.
